### PR TITLE
[MARTIFACT-44] Integration test Handle maven-shade-plugin useDependencyReducedPomInJar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ out/
 /dependencies.xml
 .java-version
 .checkstyle
+**/dependency-reduced-pom.xml
+**/target/

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,9 @@
               </goals>
               <debug>false</debug>
               <showErrors>true</showErrors>
+              <setupIncludes>
+                <setupInclude>setup/pom.xml</setupInclude>
+              </setupIncludes>
             </configuration>
           </plugin>
         </plugins>

--- a/src/it/include-drp/invoker.properties
+++ b/src/it/include-drp/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# 1) install
+invoker.goals.1=clean install
+# 2) rebuild (without install) + compare (MUST be done in a single invocation !)
+invoker.goals.2=clean verify artifact:compare

--- a/src/it/include-drp/pom.xml
+++ b/src/it/include-drp/pom.xml
@@ -1,0 +1,125 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example.maven.plugins.it</groupId>
+  <artifactId>include-drp</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple IT verifying the useDependencyReducedPomInJar with artifact:compare use case.</description>
+
+  <properties>
+    <target.java.version>1.8</target.java.version>
+    <target.java.release>8</target.java.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <maven.compiler.source>${target.java.version}</maven.compiler.source>
+    <maven.compiler.target>${target.java.version}</maven.compiler.target>
+    <maven.compiler.release>${target.java.release}</maven.compiler.release>
+
+    <project.build.outputTimestamp>2009-02-01T02:27:00Z</project.build.outputTimestamp>
+  </properties>
+
+  <prerequisites>
+    <maven>3.0.5</maven>
+  </prerequisites>
+
+  <scm>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/maven-studies.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-studies.git</developerConnection>
+    <url>https://github.com/apache/maven-studies/tree/${project.scm.tag}</url>
+    <tag>maven-buildinfo-plugin</tag>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>local-snapshots</id>
+      <url>file://${basedir}/target/remote-repo</url>
+      <uniqueVersion>false</uniqueVersion>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>nl.example.printer</groupId>
+      <artifactId>print</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <!-- Needed for reproducible builds -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>inject-problematic-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <useDependencyReducedPomInJar>true</useDependencyReducedPomInJar>
+              <minimizeJar>true</minimizeJar>
+              <filters>
+                <filter>
+                  <artifact>nl.example.printer:print</artifact>
+                  <excludes>
+                    <exclude>META-INF/services/**</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>nl.example.print</pattern>
+                  <shadedPattern>org.apache.shaded.nl.example.print</shadedPattern>
+                </relocation>
+              </relocations>
+
+              <artifactSet>
+                <includes>
+                  <artifact>nl.example.printer:print</artifact>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/src/it/include-drp/src/main/java/com/example/app/Main.java
+++ b/src/it/include-drp/src/main/java/com/example/app/Main.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.app;
+
+import nl.example.print.Printer;
+
+public class Main {
+    public static void main(String[] args) {
+        new Printer().print("Hello World");
+    }
+}

--- a/src/it/setup/invoker.properties
+++ b/src/it/setup/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# 1) install
+invoker.goals.1=clean install
+# 2) rebuild (without install) + compare (MUST be done in a single invocation !)
+invoker.goals.2=clean verify artifact:compare

--- a/src/it/setup/pom.xml
+++ b/src/it/setup/pom.xml
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>nl.example.printer</groupId>
+  <artifactId>print</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple dependency that is needed during later tests.</description>
+
+  <properties>
+    <target.java.version>1.8</target.java.version>
+    <target.java.release>8</target.java.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <maven.compiler.source>${target.java.version}</maven.compiler.source>
+    <maven.compiler.target>${target.java.version}</maven.compiler.target>
+    <maven.compiler.release>${target.java.release}</maven.compiler.release>
+
+    <project.build.outputTimestamp>2009-02-01T02:27:00Z</project.build.outputTimestamp>
+  </properties>
+
+  <prerequisites>
+    <maven>3.0.5</maven>
+  </prerequisites>
+
+  <scm>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/maven-studies.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-studies.git</developerConnection>
+    <url>https://github.com/apache/maven-studies/tree/${project.scm.tag}</url>
+    <tag>maven-buildinfo-plugin</tag>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>local-snapshots</id>
+      <url>file://${basedir}/target/remote-repo</url>
+      <uniqueVersion>false</uniqueVersion>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <!-- Needed for reproducible builds -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/setup/src/main/java/nl/example/print/Printer.java
+++ b/src/it/setup/src/main/java/nl/example/print/Printer.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package nl.example.print;
+
+public class Printer {
+    public void print(String output) {
+        System.out.println(output);
+    }
+}

--- a/src/it/setup/src/main/java/nl/example/print/Unused.java
+++ b/src/it/setup/src/main/java/nl/example/print/Unused.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package nl.example.print;
+
+public class Unused {
+    public void print(String output) {
+        System.out.println(output);
+    }
+}


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/MARTIFACT-44 @hboutemy asked for a reproduction of the issue.

What better way to provide a reproduction than a new test for the project itself.
So this is ONLY an integration test that creates and installs a dependency which is then used, shaded, minimized and the reduced pom is then injected into the jar file.

So this pull request will FAIL the build because it does not solve the problem I ran into, only show it and facilitate reproduction by others.

During the install of the `include-drp` integration test you see (simplified for readability):
```
[INFO] --- maven-install-plugin:2.4:install (default-install) @ include-drp ---
[INFO] Installing include-drp-1.0-SNAPSHOT.jar to ~/.m2/.../include-drp-1.0-SNAPSHOT.jar
[INFO] Installing dependency-reduced-pom.xml to ~/.m2/.../include-drp-1.0-SNAPSHOT.pom
```
Then after a rebuild without install you run the `artifact:compare` and you get (simplified for readability):
```
[INFO] --- maven-artifact-plugin:3.4.0:compare (default-cli) @ include-drp ---
...
[ERROR] size mismatch include-drp-1.0-SNAPSHOT.pom: investigate with diffoscope target/reference/include-drp-1.0-SNAPSHOT.pom pom.xml
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
```

Closer inspection shows `dependency-reduced-pom.xml`, the pom.xml IN the second build of the jar and the `target/reference/include-drp-1.0-SNAPSHOT.pom` to be the same (so the build IS reproducible!).
Yet both are very different from the `pom.xml` against which the compare is done which fails the build.