### PR TITLE
Martifact 53 change message

### DIFF
--- a/src/it/check-buildplan-outside-timestamp/invoker.properties
+++ b/src/it/check-buildplan-outside-timestamp/invoker.properties
@@ -16,4 +16,3 @@
 # under the License.
 
 invoker.goals=artifact:check-buildplan
-invoker.buildResult=failure

--- a/src/it/check-buildplan-outside-timestamp/pom.xml
+++ b/src/it/check-buildplan-outside-timestamp/pom.xml
@@ -28,7 +28,7 @@
   <groupId>org.apache.maven.plugins.it</groupId>
   <artifactId>check-fail</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <description>check-buildplan expected to fail because outputTimestamp is inherited form a POM outside the reactor</description>
+  <description>check-buildplan expected to warn because outputTimestamp is inherited form a POM outside the reactor</description>
 
   <build>
     <pluginManagement>

--- a/src/it/check-buildplan-outside-timestamp/verify.groovy
+++ b/src/it/check-buildplan-outside-timestamp/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def buildLog = new File ( basedir , "build.log" )
+assert buildLog.text.contains( "[WARNING] The project.build.outputTimestamp property should not be inherited from outside this project. It should be defined in the POM " )

--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CheckBuildPlanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CheckBuildPlanMojo.java
@@ -183,8 +183,11 @@ public class CheckBuildPlanMojo extends AbstractMojo {
             }
             String prop = reactorParent.getOriginalModel().getProperties().getProperty("project.build.outputTimestamp");
             if (prop == null) {
-                getLog().error("project.build.outputTimestamp property should not be inherited but defined in "
-                        + (parentInReactor ? "parent POM from reactor " : "POM ") + reactorParent.getFile());
+                getLog().warn(
+                                "The project.build.outputTimestamp property should not be inherited from outside this project. "
+                                        + "It should be defined in the "
+                                        + (parentInReactor ? "local parent POM " : "POM ")
+                                        + reactorParent.getFile());
                 return true;
             }
         }

--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CheckBuildPlanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CheckBuildPlanMojo.java
@@ -188,7 +188,7 @@ public class CheckBuildPlanMojo extends AbstractMojo {
                                         + "It should be defined in the "
                                         + (parentInReactor ? "local parent POM " : "POM ")
                                         + reactorParent.getFile());
-                return true;
+                return false;
             }
         }
         return false;


### PR DESCRIPTION
My proposed new message https://issues.apache.org/jira/browse/MARTIFACT-53

In the IT it now says
```
[WARNING] The project.build.outputTimestamp property should not be inherited from outside this project. It should be defined in the POM /home/nbasjes/workspace/Apache/maven-artifact-plugin/target/it/check-buildplan-fail/pom.xml
```

Because I was not sure if you wanted to let this problem pass the build I have separated the message and passing the build (instead of the current failing) in 2 commits.

@hboutemy Is this what you had in mind?
