### PR TITLE
Improve error handling when copying aggregate file

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/AbstractBuildinfoMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/AbstractBuildinfoMojo.java
@@ -221,7 +221,7 @@ public abstract class AbstractBuildinfoMojo extends AbstractMojo {
             FileUtils.copyFile(aggregate, rootCopy);
             getLog().info("Aggregate " + extension.substring(1) + " copied to " + rootCopy);
         } catch (IOException ioe) {
-            throw new MojoExecutionException("Could not copy " + aggregate + "to " + rootCopy);
+            throw new MojoExecutionException("Could not copy " + aggregate + " to " + rootCopy, ioe);
         }
     }
 


### PR DESCRIPTION
My [build](https://github.com/itsallcode/openfasttrace/actions/runs/8220743060/job/22480254964?pr=403) failed with the following error message when running the `compare` goal (complete log below):

```
Failed to execute goal org.apache.maven.plugins:maven-artifact-plugin:3.5.0:compare (default-cli) on project openfasttrace-reporter-plaintext: Could not copy D:\a\openfasttrace\openfasttrace\reporter\plaintext\target\openfasttrace-reporter-plaintext-3.8.0.buildcompareto D:\a\openfasttrace\openfasttrace\target\openfasttrace-root-0.0.0.buildcompare
```

The error message does not contain the cause exception, so it's hard to debug the problem. This PR adds the caught `IOException` as cause to the re-thrown `MojoExecutionException` and fixes formatting of the error message.

Complete log of the failing build:

```
...
[INFO] --- maven-artifact-plugin:3.5.0:compare (default-cli) @ openfasttrace-exporter-specobject ---
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/itsallcode/openfasttrace/openfasttrace-exporter-specobject/3.8.0/openfasttrace-exporter-specobject-3.8.0.buildinfo
[INFO] Reference buildinfo file not found: it will be generated from downloaded reference artifacts
[INFO] Reference build java.version: 21 (from MANIFEST.MF Build-Jdk-Spec)
[INFO] Reference build os.name: Windows (from pom.properties newline)
[INFO] Minimal buildinfo generated from downloaded artifacts: D:\a\openfasttrace\openfasttrace\exporter\specobject\target\reference\openfasttrace-exporter-specobject-3.8.0.buildinfo
[INFO] Reproducible Build output summary: 3 files ok
[INFO] Reproducible Build output comparison saved to D:\a\openfasttrace\openfasttrace\exporter\specobject\target\openfasttrace-exporter-specobject-3.8.0.buildcompare
[INFO] Aggregate buildcompare copied to D:\a\openfasttrace\openfasttrace\target\openfasttrace-root-0.0.0.buildcompare
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] OpenFastTrace Parent 3.8.0 ......................... SUCCESS [  2.496 s]
[INFO] OpenFastTrace API 3.8.0 ............................ SUCCESS [  7.111 s]
[INFO] OpenFastTrace Test utilities 3.8.0 ................. SUCCESS [  8.286 s]
[INFO] OpenFastTrace Core 3.8.0 ........................... SUCCESS [ 32.392 s]
[INFO] OpenFastTrace Exporters Utils 3.8.0 ................ SUCCESS [ 30.946 s]
[INFO] OpenFastTrace Specobject Exporter 3.8.0 ............ SUCCESS [  5.329 s]
[INFO] OpenFastTrace Markdown Importer 3.8.0 .............. SUCCESS [ 31.651 s]
[INFO] OpenFastTrace Common XML Parser 3.8.0 .............. SUCCESS [ 10.127 s]
[INFO] OpenFastTrace Specobject Importer 3.8.0 ............ SUCCESS [ 13.751 s]
[INFO] OpenFastTrace Tag Importer 3.8.0 ................... SUCCESS [ 35.317 s]
[INFO] OpenFastTrace Zip Importer 3.8.0 ................... SUCCESS [ 17.245 s]
[INFO] OpenFastTrace Plaintext Reporter 3.8.0 ............. FAILURE [ 16.518 s]
[INFO] OpenFastTrace HTML Reporter 3.8.0 .................. SUCCESS [ 15.924 s]
[INFO] OpenFastTrace augmented specobject Reporter 3.8.0 .. SKIPPED
[INFO] OpenFastTrace Product 3.8.0 ........................ SKIPPED
[INFO] OpenFastTrace Root Project 0.0.0 ................... SUCCESS [  0.722 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:13 min (Wall Clock)
[INFO] Finished at: 2024-03-10T08:41:58Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.apache.maven.plugins:maven-artifact-plugin:3.5.0:compare (default-cli) on project openfasttrace-reporter-plaintext: Could not copy D:\a\openfasttrace\openfasttrace\reporter\plaintext\target\openfasttrace-reporter-plaintext-3.8.0.buildcompareto D:\a\openfasttrace\openfasttrace\target\openfasttrace-root-0.0.0.buildcompare -> [Help 1]
```