### PR TITLE
[MARTIFACT-65] BuildInfoWriter not threadsafe

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/BuildinfoMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/BuildinfoMojo.java
@@ -33,7 +33,7 @@ import org.eclipse.aether.artifact.Artifact;
  * <a href="https://reproducible-builds.org/docs/jvm/">Reproducible Builds for the JVM</a>
  * for mono-module build, and extended for multi-module build.
  */
-@Mojo(name = "buildinfo", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
+@Mojo(name = "buildinfo", defaultPhase = LifecyclePhase.VERIFY, threadSafe = false)
 public class BuildinfoMojo extends AbstractBuildinfoMojo {
     /**
      * Specifies whether to attach the generated buildinfo file to the project.

--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
@@ -51,7 +51,7 @@ import static org.apache.maven.plugins.artifact.buildinfo.BuildInfoWriter.getArt
  *
  * @since 3.2.0
  */
-@Mojo(name = "compare", threadSafe = true)
+@Mojo(name = "compare", threadSafe = false)
 public class CompareMojo extends AbstractBuildinfoMojo {
     /**
      * Repository for reference build, containing either reference buildinfo file or reference artifacts.<br/>


### PR DESCRIPTION
as demonstrated by https://issues.apache.org/jira/browse/MARTIFACT-61