### PR TITLE
[MARTIFACT-70] jetty-jspc-maven-plugin is build reproducible since 11.0.0

### DIFF
--- a/src/main/resources/org/apache/maven/plugins/artifact/buildinfo/not-reproducible-plugins.properties
+++ b/src/main/resources/org/apache/maven/plugins/artifact/buildinfo/not-reproducible-plugins.properties
@@ -83,6 +83,7 @@ org.cyclonedx+cyclonedx-maven-plugin=2.7.9
 org.eclipse.sisu+sisu-maven-plugin=0.3.4
 # https://github.com/eclipse/sisu.inject/pull/5
 org.eclipse.jetty+jetty-jspc-maven-plugin=11.0.0
+# https://github.com/jetty/jetty.project/issues/12295
 
 org.glassfish.hk2+hk2-inhabitant-generator=3.0.5
 # https://github.com/eclipse-ee4j/glassfish-hk2/pull/821

--- a/src/main/resources/org/apache/maven/plugins/artifact/buildinfo/not-reproducible-plugins.properties
+++ b/src/main/resources/org/apache/maven/plugins/artifact/buildinfo/not-reproducible-plugins.properties
@@ -82,7 +82,7 @@ org.cyclonedx+cyclonedx-maven-plugin=2.7.9
 
 org.eclipse.sisu+sisu-maven-plugin=0.3.4
 # https://github.com/eclipse/sisu.inject/pull/5
-org.eclipse.jetty+jetty-jspc-maven-plugin=fail:https://github.com/eclipse/jetty.project/
+org.eclipse.jetty+jetty-jspc-maven-plugin=11.0.0
 
 org.glassfish.hk2+hk2-inhabitant-generator=3.0.5
 # https://github.com/eclipse-ee4j/glassfish-hk2/pull/821


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
