### PR TITLE
copy aggregate compare only on last

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/AbstractBuildinfoMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/AbstractBuildinfoMojo.java
@@ -377,7 +377,7 @@ public abstract class AbstractBuildinfoMojo extends AbstractMojo {
         }
     }
 
-    private MavenProject getLastProject() {
+    protected MavenProject getLastProject() {
         int i = session.getProjects().size();
         while (i > 0) {
             MavenProject project = session.getProjects().get(--i);

--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
@@ -248,7 +248,12 @@ public class CompareMojo extends AbstractBuildinfoMojo {
         } else {
             getLog().info(saved);
         }
-        buildcompare = copyAggregateToRoot(buildcompare);
+        if (session.getProjects().size() > 1) {
+            MavenProject last = getLastProject();
+            if (project == last) {
+                buildcompare = copyAggregateToRoot(buildcompare);
+            }
+        }
 
         if (ko + missing > 0) {
             getLog().error("[Reproducible Builds] to analyze the differences, see diffoscope instructions in "


### PR DESCRIPTION
```
[INFO] --- artifact:3.6.0:compare (default-cli) @ gson-parent ---
[INFO] Reference buildinfo file not found: it will be generated from downloaded reference artifacts
[INFO] Minimal buildinfo generated from downloaded artifacts: /tmp/gson-2.13.1/target/reference/gson-parent-2.13.1.buildinfo
[INFO] Reproducible Build output summary: 1 files ok
[INFO] Reproducible Build output comparison saved to /tmp/gson-2.13.1/target/gson-parent-2.13.1.buildcompare
[INFO] Aggregate buildcompare copied to /tmp/gson-2.13.1/target/gson-parent-2.13.1.buildcompare
```

this is not aggregate buildcompare: aggregate is the next module