### PR TITLE
Add build environment description to `artifact:describe-build-output`

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/DescribeBuildOutputMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/DescribeBuildOutputMojo.java
@@ -74,11 +74,26 @@ public class DescribeBuildOutputMojo extends AbstractBuildinfoMojo {
 
         diagnose(outputTimestamp, getLog(), project, session, effective);
         getLog().info("");
+        describeBuildEnvironment();
+        getLog().info("");
         describeBuildOutput();
     }
 
     private Path rootPath;
     private BuildInfoWriter bi;
+
+    private void describeBuildEnvironment() {
+        getLog().info("Build environment information");
+        getLog().info("  java.version=" + System.getProperty("java.version"));
+        getLog().info("  java.vendor=" + System.getProperty("java.vendor"));
+        getLog().info("  java.home=" + System.getProperty("java.home"));
+        getLog().info("  os.name=" + System.getProperty("os.name"));
+        getLog().info("  os.version=" + System.getProperty("os.version"));
+        getLog().info("  os.arch=" + System.getProperty("os.arch"));
+        getLog().info("  mvn.version=" + rtInformation.getMavenVersion());
+        getLog().info("  line.separator="
+                + System.lineSeparator().replace("\r", "\\r").replace("\n", "\\n"));
+    }
 
     private void describeBuildOutput() throws MojoExecutionException {
         rootPath = session.getTopLevelProject().getBasedir().toPath();

--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/DescribeBuildOutputMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/DescribeBuildOutputMojo.java
@@ -83,15 +83,15 @@ public class DescribeBuildOutputMojo extends AbstractBuildinfoMojo {
     private BuildInfoWriter bi;
 
     private void describeBuildEnvironment() {
-        getLog().info("Build environment information");
-        getLog().info("  java.version=" + System.getProperty("java.version"));
-        getLog().info("  java.vendor=" + System.getProperty("java.vendor"));
-        getLog().info("  java.home=" + System.getProperty("java.home"));
-        getLog().info("  os.name=" + System.getProperty("os.name"));
-        getLog().info("  os.version=" + System.getProperty("os.version"));
-        getLog().info("  os.arch=" + System.getProperty("os.arch"));
-        getLog().info("  mvn.version=" + rtInformation.getMavenVersion());
-        getLog().info("  line.separator="
+        getLog().info("Build environment information" + System.lineSeparator()
+                + "        - java.version=" + System.getProperty("java.version") + System.lineSeparator()
+                + "        - java.vendor=" + System.getProperty("java.vendor") + System.lineSeparator()
+                + "        - java.home=" + System.getProperty("java.home") + System.lineSeparator()
+                + "        - os.name=" + System.getProperty("os.name") + System.lineSeparator()
+                + "        - os.version=" + System.getProperty("os.version") + System.lineSeparator()
+                + "        - os.arch=" + System.getProperty("os.arch") + System.lineSeparator()
+                + "        - mvn.version=" + rtInformation.getMavenVersion() + System.lineSeparator()
+                + "        - line.separator="
                 + System.lineSeparator().replace("\r", "\\r").replace("\n", "\\n"));
     }
 


### PR DESCRIPTION
Fixes : #192 

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

----

This change enhances the `artifact:describe-build-output` goal by including a description of the build environment in its output.

```
[INFO] --- artifact:3.6.2-SNAPSHOT:describe-build-output (default-cli) @ maven-artifact-plugin ---
[INFO] outputTimestamp = 2025-09-29T16:18:23Z
[INFO] plugin outputTimestamp parameter diagnostics:
        - plugin outputTimestamp parameter (defaultValue="${project.build.outputTimestamp}") = 2025-09-29T16:18:23Z
        - project.build.outputTimestamp property from project = 2025-09-29T16:18:23Z
        - project.build.outputTimestamp property from project model = 2025-09-29T16:18:23Z
        - project.build.outputTimestamp property from project original model = 2025-09-29T16:18:23Z
[INFO] Inheritance analysis for property:
        - current org.apache.maven.plugins:maven-artifact-plugin:maven-plugin:3.6.2-SNAPSHOT property = 2025-09-29T16:18:23Z
        - external parent org.apache.maven.plugins:maven-plugins:pom:45 property = 2025-06-14T08:21:05Z
[INFO] 
[INFO] Build environment information
[INFO]   java.version=21
[INFO]   java.vendor=Oracle Corporation
[INFO]   java.home=C:\Users\harsh.mehta\Harsh\JDK-21\jdk-21
[INFO]   os.name=Windows 11
[INFO]   os.version=10.0
[INFO]   os.arch=amd64
[INFO]   mvn.version=3.9.11
[INFO]   line.separator=\r\n
[INFO] 
[INFO] parent in reactor: org.apache.maven.plugins:maven-artifact-plugin @ pom.xml (1 module), property = 2025-09-29T16:18:23Z
[INFO] 
[INFO] groupId: org.apache.maven.plugins (1 artifactId)
```
