### PR TITLE
replace info message with debug

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/ReferenceBuildinfoUtil.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/ReferenceBuildinfoUtil.java
@@ -102,7 +102,7 @@ class ReferenceBuildinfoUtil {
     File downloadOrCreateReferenceBuildinfo(
             RemoteRepository repo, MavenProject project, File buildinfoFile, boolean mono)
             throws MojoExecutionException {
-        File referenceBuildinfo = downloadReferenceBuildinfo(repo, project);
+        File referenceBuildinfo = downloadReferenceBuildinfo(repo, project, buildinfoFile);
 
         if (referenceBuildinfo != null) {
             log.warn("dropping downloaded reference buildinfo because it may be generated"
@@ -190,7 +190,7 @@ class ReferenceBuildinfoUtil {
                     throw new MojoExecutionException("Write error to " + referenceBuildinfo);
                 }
 
-                log.info("Minimal buildinfo generated from downloaded artifacts: " + referenceBuildinfo);
+                log.debug("Minimal buildinfo generated from downloaded artifacts: " + referenceBuildinfo);
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Error creating file " + referenceBuildinfo, e);
@@ -252,18 +252,20 @@ class ReferenceBuildinfoUtil {
         return null;
     }
 
-    private File downloadReferenceBuildinfo(RemoteRepository repo, MavenProject project) throws MojoExecutionException {
+    private File downloadReferenceBuildinfo(RemoteRepository repo, MavenProject project, File buildinfoFile)
+            throws MojoExecutionException {
         Artifact buildinfo = new DefaultArtifact(
                 project.getGroupId(), project.getArtifactId(), null, "buildinfo", project.getVersion());
         try {
             File file = downloadReference(repo, buildinfo);
 
-            log.info("Reference buildinfo file found, copied to " + file);
+            log.info("Reference buildinfo file found in repo, copied to " + file);
 
             return file;
         } catch (ArtifactResolutionException e) {
-            log.info("Reference buildinfo file not found: "
-                    + "it will be generated from downloaded reference artifacts");
+            log.info("Reference buildinfo file not found in repo: "
+                    + "it will be generated from downloaded reference artifacts to "
+                    + new File(referenceDir, buildinfoFile.getName()));
         }
 
         return null;


### PR DESCRIPTION
remove one INFO line = the "Minimal buildinfo generated from downloaded artifacts" at the end

```
[INFO] --- artifact:3.6.1:compare (default-cli) @ messages-ndjson ---
[INFO] Saved info on build to /home/herve/dev/maven/misc/reproducible-central/content/io/cucumber/messages-ndjson/buildcache/messages-ndjson/java/target/messages-ndjson-0.3.5.buildinfo
[INFO] Checking against reference build from central...
[INFO] Reference buildinfo file not found: it will be generated from downloaded reference artifacts
[INFO] Reference build java.version: 17 (from MANIFEST.MF Build-Jdk-Spec)
[INFO] Reference build os.name: Unix (from pom.properties newline)
[INFO] Minimal buildinfo generated from downloaded artifacts: /home/herve/dev/maven/misc/reproducible-central/content/io/cucumber/messages-ndjson/buildcache/messages-ndjson/java/target/reference/messages-ndjson-0.3.5.buildinfo
[INFO] [Reproducible Builds] rebuild comparison result: 3 files match
```

with a debug message, not displayed in normal ouotput:
```
[INFO] --- artifact:3.6.2-SNAPSHOT:compare (default-cli) @ messages-ndjson ---
[INFO] Saved info on build to /home/herve/dev/maven/misc/reproducible-central/content/io/cucumber/messages-ndjson/buildcache/messages-ndjson/java/target/messages-ndjson-0.3.5.buildinfo
[INFO] Checking against reference build from central...
[INFO] Reference buildinfo file not found in repo: it will be generated from downloaded reference artifacts to /home/herve/dev/maven/misc/reproducible-central/content/io/cucumber/messages-ndjson/buildcache/messages-ndjson/java/target/reference/messages-ndjson-0.3.5.buildinfo
[INFO] Reference build java.version: 17 (from MANIFEST.MF Build-Jdk-Spec)
[INFO] Reference build os.name: Unix (from pom.properties newline)
[INFO] [Reproducible Builds] rebuild comparison result: 3 files match
```

will ease vote results, as I had to remove by hand the noisy line to only keep the interesting 3 ones:
```
[INFO] Reference build java.version: 17 (from MANIFEST.MF Build-Jdk-Spec)
[INFO] Reference build os.name: Unix (from pom.properties newline)
[INFO] [Reproducible Builds] rebuild comparison result: 3 files match
```
