### PR TITLE
fix wget command with double slash

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
@@ -316,7 +316,9 @@ public class CompareMojo extends AbstractBuildinfoMojo {
         }
         if (!reference.exists()) {
             RemoteRepository repo = createReferenceRepo();
-            String url = repo.getUrl() + "/"
+            String baseUrl = repo.getUrl();
+            String url = baseUrl
+                    + (baseUrl.endsWith("/") ? "" : "/")
                     + session.getRepositorySession()
                             .getLocalRepositoryManager()
                             .getPathForRemoteArtifact(a, repo, null);


### PR DESCRIPTION
`//` issue found when running on a project:
```
[ERROR] missing reference file mismatch hop-transform-standardizephonenumber-2.16.0.zip: investigate with wget https://repo1.maven.org/maven2//org/apache/hop/hop-transform-standardizephonenumber/2.16.0/hop-transform-standardizephonenumber-2.16.0.zip; ls -l plugins/transforms/standardizephonenumber/target/hop-transform-standardizephonenumber-2.16.0.zip
```

stupid missing check