### PR TITLE
describe-build-output: protect sha256 against unexpected directory

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/DescribeBuildOutputMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/DescribeBuildOutputMojo.java
@@ -218,6 +218,9 @@ public class DescribeBuildOutputMojo extends AbstractBuildinfoMojo {
     }
 
     private String sha256(File file) throws MojoExecutionException {
+        if (file.isDirectory()) {
+            return "directory";
+        }
         try (InputStream is = Files.newInputStream(file.toPath())) {
             return DigestUtils.sha256Hex(is);
         } catch (IOException ioe) {


### PR DESCRIPTION
sometimes, unexpectedly, there are directories instead of files in `artifact.getFile()`, which causes
```
Caused by: java.io.IOException: Is a directory
    at sun.nio.ch.UnixFileDispatcherImpl.read0(Native Method)
    at sun.nio.ch.UnixFileDispatcherImpl.read(UnixFileDispatcherImpl.java:51)
    at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:341)
    at sun.nio.ch.IOUtil.read(IOUtil.java:307)
    at sun.nio.ch.IOUtil.read(IOUtil.java:284)
    at sun.nio.ch.FileChannelImpl.implRead(FileChannelImpl.java:251)
    at sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:231)
    at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:90)
    at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:119)
    at org.apache.commons.codec.digest.DigestUtils.updateDigest(DigestUtils.java:1313)
    at org.apache.commons.codec.digest.DigestUtils.digest(DigestUtils.java:112)
    at org.apache.commons.codec.digest.DigestUtils.sha256(DigestUtils.java:612)
    at org.apache.commons.codec.digest.DigestUtils.sha256Hex(DigestUtils.java:646)
    at org.apache.maven.plugins.artifact.buildinfo.DescribeBuildOutputMojo.sha256(DescribeBuildOutputMojo.java:206)
    at org.apache.maven.plugins.artifact.buildinfo.DescribeBuildOutputMojo.describeArtifact(DescribeBuildOutputMojo.java:186)
    at org.apache.maven.plugins.artifact.buildinfo.DescribeBuildOutputMojo.describeBuildOutput(DescribeBuildOutputMojo.java:155)
    at org.apache.maven.plugins.artifact.buildinfo.DescribeBuildOutputMojo.execute(DescribeBuildOutputMojo.java:77)
```

seen when rebuilding Shiro 3.0.0 https://github.com/jvm-repo-rebuild/reproducible-central/pull/6604

need to protect first, then we can try to understand what in the build caused that