### PR TITLE
ignore skip deploy with extension plugins that bypass deploy

### DIFF
--- a/src/it/buildinfo-skip-extensions/invoker.properties
+++ b/src/it/buildinfo-skip-extensions/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals.1=verify -Pnexus-staging artifact:describe-build-output
+
+invoker.goals.2=verify -Pcentral-publishing artifact:describe-build-output

--- a/src/it/buildinfo-skip-extensions/modA/pom.xml
+++ b/src/it/buildinfo-skip-extensions/modA/pom.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.it</groupId>
+    <artifactId>multi</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>multi-modA</artifactId>
+  <name>multi-module module A</name>
+
+  <properties>
+    <!-- should be ignored, as the plugin deletes deploy from execution -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+</project>

--- a/src/it/buildinfo-skip-extensions/modB/pom.xml
+++ b/src/it/buildinfo-skip-extensions/modB/pom.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.it</groupId>
+    <artifactId>multi</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>multi-modB</artifactId>
+  <name>multi-module module B</name>
+
+
+  <properties>
+    <!-- should be ignored, as the plugin deletes deploy from execution -->
+    <maven.install.skip>true</maven.install.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+    <groupId>org.apache.maven.plugins.it</groupId>
+    <artifactId>multi-modA</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/buildinfo-skip-extensions/modSkip/pom.xml
+++ b/src/it/buildinfo-skip-extensions/modSkip/pom.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.it</groupId>
+    <artifactId>multi</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>multi-mod-skip</artifactId>
+  <name>multi-module module that skips the extension plugin</name>
+  <description>then should not be added to buildinfo</description>
+
+  <properties>
+    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+    <skipPublishing>true</skipPublishing>
+  </properties>
+</project>

--- a/src/it/buildinfo-skip-extensions/pom.xml
+++ b/src/it/buildinfo-skip-extensions/pom.xml
@@ -1,0 +1,117 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.it</groupId>
+  <artifactId>multi</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <description>An IT verifying automatic skip based on nexus-staging-maven-plugin and central-publishing-maven-plugin.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>2026-08-03T10:04:00Z</project.build.outputTimestamp>
+  </properties>
+
+  <prerequisites>
+    <maven>3.0.5</maven>
+  </prerequisites>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>local-snapshots</id>
+      <url>file://${basedir}/target/remote-repo</url>
+      <uniqueVersion>false</uniqueVersion>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <modules>
+    <module>modSkip</module>
+    <module>modB</module>
+    <module>modA</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>@version.maven-install-plugin@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>@version.maven-deploy-plugin@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>buildinfo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>nexus-staging</id>
+      <build>
+        <plugins>
+          <plugin>
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nexus-staging-maven-plugin</artifactId>
+              <version>1.7.0</version>
+              <extensions>true</extensions>
+          </plugin>
+        </plugins>
+        <directory>target-nexus-staging</directory>
+      </build>
+    </profile>
+    <profile>
+      <id>central-publishing</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.11.0</version>
+            <extensions>true</extensions>
+          </plugin>
+        </plugins>
+        <directory>target-central-publishing</directory>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/src/it/buildinfo-skip-extensions/verify.groovy
+++ b/src/it/buildinfo-skip-extensions/verify.groovy
@@ -1,0 +1,57 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def check(String target) {
+    // check existence of generated aggregate buildinfo in target and root copy
+    File buildinfoFile = new File(basedir, target + "/multi-1.0-SNAPSHOT.buildinfo");
+    assert buildinfoFile.isFile()
+
+    File modB = new File(basedir, "modB/" + target + "/multi-modB-1.0-SNAPSHOT.buildinfo")
+    assert modB.isFile()
+
+    // check generated aggregate buildinfo content
+    String buildinfo = modB.text
+    assert buildinfo.contains("group-id=org.apache.maven.plugins.it")
+    assert buildinfo.contains("artifact-id=multi")
+    assert buildinfo.contains("version=1.0-SNAPSHOT")
+    assert buildinfo.contains("outputs.1.coordinates=org.apache.maven.plugins.it:multi-modA")
+    assert buildinfo.contains("outputs.1.0.filename=multi-modA-1.0-SNAPSHOT.pom")
+
+    if (mavenVersion.startsWith('4.')) {
+        assert buildinfo.contains("outputs.1.2.filename=multi-modA-1.0-SNAPSHOT.jar")
+    } else {
+        assert buildinfo.contains("outputs.1.1.filename=multi-modA-1.0-SNAPSHOT.jar")
+    }
+
+    assert buildinfo.contains("outputs.2.coordinates=org.apache.maven.plugins.it:multi-modB")
+    assert buildinfo.contains("outputs.2.0.filename=multi-modB-1.0-SNAPSHOT.pom")
+
+    if (mavenVersion.startsWith('4.')) {
+        assert buildinfo.contains("outputs.2.2.filename=multi-modB-1.0-SNAPSHOT.jar")
+    } else {
+        assert buildinfo.contains("outputs.2.1.filename=multi-modB-1.0-SNAPSHOT.jar")
+    }
+
+    assert !buildinfo.contains(".buildinfo")
+    assert !buildinfo.contains("outputs.3")
+}
+
+check("target-nexus-staging")
+check("target-central-publishing")

--- a/src/it/buildinfo-skip-install-deploy/verify.groovy
+++ b/src/it/buildinfo-skip-install-deploy/verify.groovy
@@ -22,6 +22,7 @@
 File buildinfoFile = new File( basedir, "target/multi-1.0-SNAPSHOT.buildinfo" );
 assert buildinfoFile.isFile()
 
+// Skipping intermediate goal run, aggregate will be multi-modB
 File modA = new File( basedir, "modA/target/multi-modA-1.0-SNAPSHOT.buildinfo")
 assert !modA.isFile()
 

--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/PluginUtil.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/PluginUtil.java
@@ -34,10 +34,15 @@ class PluginUtil {
     private static final String CENTRAL_PUBLISHING = "central-publishing";
 
     static boolean isSkip(MavenProject project) {
-        return isSkip(project, "install")
-                || isSkip(project, "deploy")
-                || isSkip(project, NEXUS_STAGING)
-                || isSkip(project, CENTRAL_PUBLISHING);
+        // check the extension plugins first, as using them drops deploy
+        if (getPlugin(project, "org.sonatype.plugins:" + NEXUS_STAGING + "-maven-plugin") != null) {
+            return isSkip(project, NEXUS_STAGING);
+        }
+        if (getPlugin(project, "org.sonatype.central:" + CENTRAL_PUBLISHING + "-maven-plugin") != null) {
+            return isSkip(project, CENTRAL_PUBLISHING);
+        }
+        // install/deploy are really used
+        return isSkip(project, "install") || isSkip(project, "deploy");
     }
 
     private static boolean isSkip(MavenProject project, String id) {


### PR DESCRIPTION
while rebuilding flexmark-java 0.64.6 https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/com/vladsch/flexmark/flexmark-java/README.md

I had to disable skip auto-detection because this project uses nexus-staging plugin extension AND disables deploy: https://github.com/vsch/flexmark-java/blob/0.64.6/pom.xml#L148
