### PR TITLE
Implement getOutputPath() and deprecate getOutputName()

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/ReproducibleCentralReport.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/ReproducibleCentralReport.java
@@ -185,8 +185,20 @@ public class ReproducibleCentralReport extends AbstractMavenReport {
         }
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
     @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "reproducible-central";
     }
 


### PR DESCRIPTION
Adopts the report output method that Maven Reporting API 4.0.0 introduced, following the [report plugin guide](https://maven.apache.org/guides/plugin/guide-java-report-plugin-development.html) and the plugins that already moved (maven-javadoc-plugin, maven-pmd-plugin, and the eight merged this week): `getOutputPath()` carries the value, and `getOutputName()` stays as a deprecated delegate because the API still declares it abstract.

1 report here — reproducible-central. No behaviour change: the rendered report paths are the same strings.

Verified: `mvn verify` → BUILD SUCCESS.

*This change was created with AI assistance.*
