### PR TITLE
Fix repository filename lookup without a directory

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -307,7 +308,9 @@ public class CompareMojo extends AbstractBuildinfoMojo {
         File actual = a.getFile();
         // notice: actual file name may have been defined in pom
         // reference file name is taken from repository format
-        File reference = new File(new File(referenceDir, a.getGroupId()), getRepositoryFilename(a));
+        String repositoryPath =
+                session.getRepositorySession().getLocalRepositoryManager().getPathForLocalArtifact(a);
+        File reference = new File(new File(referenceDir, a.getGroupId()), getRepositoryFilename(repositoryPath));
         if (actual == null) {
             return "missing file for " + ArtifactIdUtils.toId(a) + " reference = " + relative(reference)
                     + " actual = null";
@@ -325,9 +328,8 @@ public class CompareMojo extends AbstractBuildinfoMojo {
         return "diffoscope " + relative(reference) + " " + relative(actual);
     }
 
-    private String getRepositoryFilename(Artifact a) {
-        String path = session.getRepositorySession().getLocalRepositoryManager().getPathForLocalArtifact(a);
-        return path.substring(path.lastIndexOf('/'));
+    static String getRepositoryFilename(String path) {
+        return Paths.get(path).getFileName().toString();
     }
 
     private static String findPrefix(Properties reference, String actualGroupId, String actualFilename) {

--- a/src/test/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojoTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.artifact.buildinfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CompareMojoTest {
+    @Test
+    void getsRepositoryFilenameWithoutDirectory() {
+        assertEquals("artifact-1.0.pom", CompareMojo.getRepositoryFilename("artifact-1.0.pom"));
+    }
+
+    @Test
+    void getsRepositoryFilenameFromRepositoryPath() {
+        assertEquals(
+                "artifact-1.0.pom", CompareMojo.getRepositoryFilename("org/example/artifact/1.0/artifact-1.0.pom"));
+    }
+}


### PR DESCRIPTION
Closes #248

## What and why

`CompareMojo` assumes a local repository manager always returns a path containing `/` and slices the string at the final separator. A repository manager may return a bare filename instead, causing `StringIndexOutOfBoundsException` before comparison starts. Use `Path` file-name extraction so both bare filenames and nested repository paths resolve to the artifact filename.

## Validation

- Added a regression test for both a separator-free filename and a nested repository path.
- Reproduced the pre-fix exception, then manually verified that both path forms return `artifact-1.0.pom` and produce the expected reference-file join.
- `mvn verify` passed.
- `mvn -Prun-its verify` passed all 16 Invoker scenarios.

## Checklist

- [x] This pull request addresses one issue without unrelated changes.
- [x] The commit has a meaningful subject and body.
- [x] Tests cover the behavioral change.
- [x] `mvn verify` passed.
- [x] `mvn -Prun-its verify` passed.
- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004.
