### PR TITLE
Quote repository URL in wget diagnostic

### DIFF
--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojo.java
@@ -320,9 +320,17 @@ public class CompareMojo extends AbstractBuildinfoMojo {
                     + session.getRepositorySession()
                             .getLocalRepositoryManager()
                             .getPathForRemoteArtifact(a, repo, null);
-            return "wget " + url + "; ls -l " + relative(actual);
+            return wgetHint(url, relative(actual));
         }
         return "diffoscope " + relative(reference) + " " + relative(actual);
+    }
+
+    static String wgetHint(String url, String actual) {
+        return "wget -- " + shellQuote(url) + "; ls -l -- " + shellQuote(actual);
+    }
+
+    private static String shellQuote(String value) {
+        return '\'' + value.replace("'", "'\"'\"'") + '\'';
     }
 
     private String getRepositoryFilename(Artifact a) {

--- a/src/test/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojoWgetHintTest.java
+++ b/src/test/java/org/apache/maven/plugins/artifact/buildinfo/CompareMojoWgetHintTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.artifact.buildinfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CompareMojoWgetHintTest {
+    @Test
+    void quotesWgetHintArguments() {
+        String url = "https://example.invalid/repository/a' b;$(touch injected)";
+        String actual = "target/it' s;$(touch injected).jar";
+
+        assertEquals(
+                "wget -- 'https://example.invalid/repository/a'\"'\"' b;$(touch injected)'; ls -l -- "
+                        + "'target/it'\"'\"' s;$(touch injected).jar'",
+                CompareMojo.wgetHint(url, actual));
+    }
+}


### PR DESCRIPTION
Closes #250

## What and why
The diagnostic hint for a reference repository is intended for users to copy into a shell. Quote repository and artifact values, including embedded apostrophes, and use option terminators so user-controlled values remain individual operands in the suggested commands.

## Validation
- Added a regression test covering apostrophes, spaces, shell delimiters, and command-substitution text in both values.
- Manually exercised the production helper with those values: the probe received each value as one argument and left a sentinel file unchanged.
- `mvn verify`
- `mvn -Prun-its verify` (16/16 scenarios)

## Checklist
- [x] This pull request addresses one issue.
- [x] The description explains what changes, how, and why.
- [x] The commit has a meaningful subject and body.
- [x] Added a behavioral unit test.
- [x] Ran `mvn verify`.
- [x] Ran `mvn -Prun-its verify`.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
