### PR TITLE
Detect fully open version ranges

### DIFF
--- a/src/it/check-buildplan-version-range-fail/pom.xml
+++ b/src/it/check-buildplan-version-range-fail/pom.xml
@@ -45,6 +45,11 @@
       <version>[3.20.0]</version>
     </dependency>
     <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>(,)</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>[2.20.0,2.21.0]</version>

--- a/src/it/check-buildplan-version-range-fail/verify.groovy
+++ b/src/it/check-buildplan-version-range-fail/verify.groovy
@@ -29,4 +29,8 @@ assert buildLog.contains(' via io.cucumber:gherkin:jar:38.0.0 has been resolved 
 
 assert buildLog.contains(' - Dependency commons-io:commons-io:jar:2.21.0 (compile) has been resolved from a version range [2.20.0,2.21.0]')
 assert buildLog.contains(' - Dependency commons-collections:commons-collections:jar:LATEST (compile) has been resolved from a version range LATEST')
+assert buildLog.readLines().any { line ->
+    line.startsWith(' - Dependency commons-cli:commons-cli:jar:')
+            && line.endsWith('has been resolved from a version range (,)')
+}
 assert !buildLog.contains(' - Dependency org.apache.commons:commons-lang3')

--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/RangesUtil.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/RangesUtil.java
@@ -137,9 +137,11 @@ public class RangesUtil {
         }
 
         if (versionConstraint.getRange() != null) {
-            return !Objects.equals(
-                    versionConstraint.getRange().getLowerBound(),
-                    versionConstraint.getRange().getUpperBound());
+            return versionConstraint.getRange().getLowerBound() == null
+                    || versionConstraint.getRange().getUpperBound() == null
+                    || !Objects.equals(
+                            versionConstraint.getRange().getLowerBound(),
+                            versionConstraint.getRange().getUpperBound());
         }
         return false;
     }


### PR DESCRIPTION
Closes #247

## What and why
A fully open `(,)` version constraint has two missing bounds. The build-plan check previously compared the bounds and treated the two missing values as a fixed version. Treat either missing bound as a range so the check reports it consistently.

## Validation
- Added the `(,)` case to the existing version-range integration fixture and asserted its diagnostic.
- Manually ran `artifact:check-buildplan` against a standalone project using `commons-cli:(,)`; it exited nonzero and reported the resolved range.
- `mvn -B -ntp verify`
- Focused `mvn -B -ntp -Prun-its verify -Dinvoker.test=check-buildplan-version-range-fail`
- Full `mvn -B -ntp -Prun-its verify` (16/16 scenarios)

## Checklist
- [x] This pull request addresses one issue.
- [x] The description explains what changes, how, and why.
- [x] The commit has a meaningful subject and body.
- [x] Added behavioral integration coverage.
- [x] Ran `mvn verify`.
- [x] Ran `mvn -Prun-its verify`.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
