### PR TITLE
Preserve check-buildplan failures

### DIFF
--- a/src/it/check-buildplan-plugin-fail/invoker.properties
+++ b/src/it/check-buildplan-plugin-fail/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=artifact:check-buildplan
+invoker.buildResult=failure

--- a/src/it/check-buildplan-plugin-fail/pom.xml
+++ b/src/it/check-buildplan-plugin-fail/pom.xml
@@ -20,36 +20,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.apache.maven.plugins.it.compare</groupId>
-  <artifactId>compare-version-range-no-fail-depMan</artifactId>
+  <groupId>org.apache.maven.plugins.it</groupId>
+  <artifactId>check-buildplan-plugin-fail</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
 
-  <description>A simple IT verifying dependencies with range in version</description>
+  <description>A simple IT verifying a known non-reproducible plugin fails the check</description>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>0</project.build.outputTimestamp>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <!-- Overwrite the version to avoid range selection -->
-      <dependency>
-        <groupId>io.cucumber</groupId>
-        <artifactId>messages</artifactId>
-        <version>32.1.0</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-  <dependencies>
-    <dependency>
-      <!-- Contains transitive dependencies with version ranges -->
-      <groupId>io.cucumber</groupId>
-      <artifactId>gherkin</artifactId>
-      <version>38.0.0</version>
-    </dependency>
-  </dependencies>
 
   <build>
     <pluginManagement>
@@ -61,5 +40,11 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.0</version>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/src/it/check-buildplan-plugin-fail/verify.groovy
+++ b/src/it/check-buildplan-plugin-fail/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def buildLog = new File(basedir, 'build.log').text
+
+assert buildLog.contains('[ERROR] plugin with non-reproducible output: org.apache.maven.plugins:maven-jar-plugin:3.1.0, require minimum 3.2.0')
+assert buildLog.contains('non-reproducible plugin or configuration found with fix available')

--- a/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CheckBuildPlanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/artifact/buildinfo/CheckBuildPlanMojo.java
@@ -170,7 +170,7 @@ public class CheckBuildPlanMojo extends AbstractMojo {
             getLog().info("No known issue in " + okCount + " plugins");
         }
 
-        fail = checkVersionRangeInDependencies();
+        fail |= checkVersionRangeInDependencies();
 
         if (fail) {
             getLog().info("current module pom.xml is " + project.getBasedir() + "/pom.xml");


### PR DESCRIPTION
Closes #241

## What and why
`check-buildplan` records reproducibility problems while it walks plugin executions, then checks dependency version ranges. Assigning the range result to `fail` overwrote an earlier plugin or output-timestamp failure. Preserve the existing state while still evaluating the range check so every detected reproducibility problem produces the configured failure.

The existing dependency-management no-fail fixture now sets an output timestamp so it remains focused on its range-policy behavior rather than the independent timestamp check.

## Validation
- Added an Invoker regression fixture with `maven-jar-plugin:3.1.0` and a configured output timestamp.
- Manually reproduced the defect: the base plugin logged the non-reproducible plugin but exited `0`; the patched plugin logged the same diagnostic and exited `1` with the final failure.
- Focused `mvn -B -Prun-its verify -Dinvoker.test=check-buildplan-plugin-fail`
- `mvn -B verify`
- Full `mvn -B -Prun-its verify` (17/17 scenarios)

## Checklist
- [x] This pull request addresses one issue.
- [x] The description explains what changes, how, and why.
- [x] The commit has a meaningful subject and body.
- [x] Added behavioral integration coverage.
- [x] Ran `mvn verify`.
- [x] Ran `mvn -Prun-its verify`.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
